### PR TITLE
Add assignment and substitution test for transform

### DIFF
--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -1,8 +1,8 @@
 var context = require('./context');
 
-module.exports = exports = function procedure(rules, prepare, err) {
+module.exports = exports = function procedure(rules, prepare, stuck) {
   prepare = prepare || function noop() {};
-  err = err || function noop() {};
+  stuck = stuck || function noop() {};
   var max = rules.length;
 
   var proceed = function proceed(ctx) {
@@ -21,7 +21,10 @@ module.exports = exports = function procedure(rules, prepare, err) {
       }
 
       if (ctx.pos === start) {
-        throw err(ctx);
+        var end = stuck(ctx);
+        if (end) {
+          return end;
+        }
       }
     }
 

--- a/lib/tokenize/index.js
+++ b/lib/tokenize/index.js
@@ -4,7 +4,7 @@ var serialize = require('./serialize');
 
 var rules = [
   'comment', 'whitespace', 'string', 'number', 'unit', 'opener', 'closer',
-  'operator', 'declaration'
+  'operator', 'reference', 'declaration'
 ].map(function resolveModules(name) {
   return require('./' + name);
 });
@@ -16,5 +16,5 @@ module.exports = exports = procedure(rules, function prepare(ctx) {
   Object.defineProperty(ctx, 'pos', trackLines);
   ctx.toJSON = serialize;
 }, function error(ctx) {
-  return new Error('Cannot proceed (at ' + ctx.line + ':' + ctx.col + ')');
+  throw new Error('Cannot proceed (at ' + ctx.line + ':' + ctx.col + ')');
 });

--- a/lib/tokenize/operator.js
+++ b/lib/tokenize/operator.js
@@ -1,24 +1,37 @@
-var symbols = ['+', '-', '/', '*', ':', '=', ',', ';'];
+var symbols = [
+  ['+', 'addition'],
+  ['/', 'division'],
+  ['*', 'multiplication'],
+  ['-', 'subtraction'],
+  [':', 'assignment'],
+  ['=', 'assignment'],
+  [';', 'terminator'],
+  [',', 'separator']
+];
 
 module.exports = exports = function operator(ctx) {
-  var operator = null;
+  var symbol = null;
+  var raw = null;
   for (var i = 0; i < symbols.length; i++) {
-    if (!(ctx.src.indexOf(symbols[i], ctx.pos) - ctx.pos)) {
-      operator = symbols[i];
+    var name = symbols[i][0];
+    if (!(ctx.src.indexOf(name, ctx.pos) - ctx.pos)) {
+      raw = name;
+      symbol = symbols[i][1];
     }
   }
-  if (!operator) {
+  if (!symbol || !raw) {
     return false;
   }
 
   ctx.out.push({
     name: 'operator',
-    value: operator,
+    type: symbol,
+    value: raw,
     pos: ctx.pos,
     line: ctx.line,
     col: ctx.col
   });
 
-  ctx.pos += operator.length;
+  ctx.pos += raw.length;
   return true;
 };

--- a/lib/tokenize/reference.js
+++ b/lib/tokenize/reference.js
@@ -1,0 +1,30 @@
+var chars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '-', '_', '.'];
+
+module.exports = exports = function declaration(ctx) {
+  if (chars.indexOf(ctx.src[ctx.pos].toLowerCase()) === -1) {
+    return false;
+  }
+
+  var pos = ctx.pos;
+  var line = ctx.line;
+  var col = ctx.col;
+
+  var name = '';
+  while (
+    ctx.src[ctx.pos] &&
+    chars.indexOf(ctx.src[ctx.pos].toLowerCase()) !== -1
+  ) {
+    name += ctx.src[ctx.pos];
+    ctx.pos++;
+  }
+
+  ctx.out.push({
+    name: 'reference',
+    value: name,
+    pos: pos,
+    line: line,
+    col: col
+  });
+  return true;
+};

--- a/lib/tokenize/whitespace.js
+++ b/lib/tokenize/whitespace.js
@@ -21,13 +21,15 @@ module.exports = exports = function whitespace(ctx) {
     return false;
   }
 
-  ctx.out.push({
-    name: 'whitespace',
-    value: symbol,
-    pos: ctx.pos,
-    line: ctx.line,
-    col: ctx.col
-  });
+  if (symbol !== 'space') {
+    ctx.out.push({
+      name: 'whitespace',
+      value: symbol,
+      pos: ctx.pos,
+      line: ctx.line,
+      col: ctx.col
+    });
+  }
 
   ctx.pos += raw.length;
   return true;

--- a/lib/transform/assignment.js
+++ b/lib/transform/assignment.js
@@ -1,0 +1,24 @@
+module.exports = exports = function assignment(ctx) {
+  var token = ctx.src[ctx.pos];
+  if (token.name !== 'operator' || token.type !== 'assignment') {
+    return false;
+  }
+
+  // Siblings involved
+  var left = ctx.src[ctx.pos - 1];
+  var right = ctx.src[ctx.pos + 1];
+
+  // Check sibling token
+  console.log(ctx.src, left, token, right);
+  if (left.name !== 'reference') {
+    return false;
+  }
+
+  ctx.out.pop();
+
+  // Assign token to stack.
+  ctx.stack[left.value] = right;
+
+  ctx.pos += 2;
+  return true;
+};

--- a/lib/transform/index.js
+++ b/lib/transform/index.js
@@ -1,21 +1,24 @@
 var procedure = require('../procedure');
 
 var rules = [
-
+  'assignment', 'substitution'
 ].map(function(name) {
   return require('./' + name);
 });
 
 module.exports = exports = procedure(rules, function prepare(ctx) {
-  ctx.out = {
-    name: 'base',
-    parent: null,
-    children: []
-  };
+  ctx.stack = {};
 }, function error(ctx) {
-  var t = ctx.src[ctx.pos];
-  var n = t.name;
-  var l = t.line;
-  var c = t.col;
-  return new Error('Unexpected token "' + n + '" (at ' + l + ':' + c + ')');
+  ctx.out.push(ctx.src[ctx.pos]);
+  if (ctx.pos >= ctx.src.length) {
+    return ctx;
+  }
+  ctx.pos++;
 });
+
+var tokenize = require('../tokenize');
+var transform = exports;
+console.log(transform(tokenize(`
+foo: 'hello'
+bar(foo)
+`).out));

--- a/lib/transform/substitution.js
+++ b/lib/transform/substitution.js
@@ -1,0 +1,13 @@
+module.exports = exports = function substitution(ctx) {
+  var token = ctx.src[ctx.pos];
+  if (
+    token.name !== 'reference' ||
+    typeof ctx.stack[token.value] === 'undefined'
+  ) {
+    return false;
+  }
+
+  ctx.out.push(ctx.stack[token.value]);
+  ctx.pos++;
+  return true;
+};


### PR DESCRIPTION
This does an interesting assignment and substitution job.  Note that this is a test.

```
foo: 'hello'
foo + 'world'
```
Initially, this text tokenizes to:
```javascript
[ { name: 'whitespace', value: 'linebreak', pos: 0, line: 1, col: 1 },

  // Definition
  { name: 'reference', value: 'foo', pos: 1, line: 1, col: 2 },
  { name: 'operator', type: 'assignment', value: ':', pos: 4, line: 1, col: 5 },
  { name: 'string', value: 'hello', pos: 7, line: 1, col: 8 },
  { name: 'whitespace', value: 'linebreak', pos: 13, line: 2, col: 1 },

  // Reference
  { name: 'reference', value: 'foo', pos: 14, line: 2, col: 2 },

  { name: 'operator', type: 'addition', value: '+', pos: 18, line: 2, col: 6 },
  { name: 'string', value: 'world', pos: 21, line: 2, col: 9 } ],
```
We can use the transformer to resolve the `Definition` into data held in the stack, then we can substitute `Reference` with that data held in the stack:
```javascript
[ { name: 'whitespace', value: 'linebreak', pos: 0, line: 1, col: 1 },
  { name: 'whitespace', value: 'linebreak', pos: 13, line: 2, col: 1 },
  { name: 'string', value: 'hello', pos: 7, line: 1, col: 8 },
  { name: 'operator', type: 'addition', value: '+', pos: 18, line: 2, col: 6 },
  { name: 'string', value: 'world', pos: 21, line: 2, col: 9 } ],
```
Of course there is more to be added, such as resolving the operators and trimming the whitespace, but it is a good start.